### PR TITLE
Fix installation instructions to download correct file, remove zip files from build step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,12 +23,9 @@ jobs:
 
             - name: Build JS
               run: npm run build
-
-            - name: Zip files
-              run: zip release.zip ./* -r
-
+              
             - name: Tar files
-              run: tar --exclude='release.zip' -czf release.tar.gz *
+              run: tar -czf release.tar.gz *
 
             - name: Release
               uses: softprops/action-gh-release@v1
@@ -36,5 +33,4 @@ jobs:
               with:
                   generate_release_notes: true
                   files: |
-                      release.zip
                       release.tar.gz

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This allows you to type in the production url and it will use that url to fetch 
 
 ## Installation
 
-* Download the zip file from the releases page.
+* Download the .tar.gz file from the releases page.
 * Go to LocalWP and press the "Addons" tab in the sidebar.
 * Press the "Installed" tab.
 * Then click the "Install from disk" button at the top right.


### PR DESCRIPTION
Currently, installation instructions tells you to download the .zip file from releases and use that to install in LocalWP, however, this is not supported. Only .tar.gz is supported. 